### PR TITLE
Add ignore_if_duplicates parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # sleuth-action
-A GitHub action to register a deploy to Sleuth
+
+A GitHub action to register a deploy to [Sleuth](https://www.sleuth.io)
 
 ## Usage
 
@@ -34,9 +35,13 @@ jobs:
         with:
           organization-slug: 'your-sleuth-organization'
           deployment-slug: 'your-deployment-slug'
+          environment: staging
+          sha: ${{ github.sha }}
+          email: ${{ github.event.pusher.email }}
           api-key: ${{ secrets.SLEUTH_API_KEY }}
       # Use the output from the `sleuth` step
       - name: Get the response status
         run: echo "Status code ${{ steps.sleuth.outputs.status }}"
-
 ```
+
+**Note** You can ontain the `deployment-slug` parameter by ensuring your code deployment is configured to track deploys using webhooks and then clicking on *Get Setup Instructions* from the gear icon menu when viewing a code deployment

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'String defining the environment to register the deploy against'
   email:
     description: 'Email address of author'
+  ignore-if-duplicate:
+    description: 'Will not cause a failure if a deploy already exists'
+    default: 'false'
 outputs:
   status:
     description: 'Response status code'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1499,12 +1499,15 @@ async function main() {
     const email = core.getInput('email');
     const apiKey = core.getInput('api-key');
     const sha = core.getInput('sha');
+    const ignoreDupes = core.getInput('ignore-if-duplicate');
+
 
     const requestUrl = `https://app.sleuth.io/api/1/deployments/${organizationSlug}/${deploymentSlug}/register_deploy`;
     core.info(`Sleuth API URL ${requestUrl}`);
 
     const data = {
       api_key: apiKey,
+      ignore_if_duplicate: ignoreDupes,
       sha,
       environment,
       email,


### PR DESCRIPTION
Add the API parameter `ignore-if-duplicate` to the payload for the github action.  The default value if not specified is `false`.  Also freshened the readme with updated parameters and a note on how to get the deployment slug.

**Testing**

Tested on a test repo to use the new action.  Tested no parameter being there and the parameter being present with a value of `true` and verified the api payload looked correct in both cases